### PR TITLE
Fix team checks when no previous teams

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -221,7 +221,7 @@ def get_team_attributes(args):
     """Displays the attribute ratings of the last generated team."""
     teams = db.get_last_teams()
     team_key = args.team
-    if not teams[team_key]:
+    if not teams[team_key].players:
         print(f"❌ No previous team '{team_key}' found.")
         return
 
@@ -245,7 +245,7 @@ def get_team_rating(args):
     """Displays the overall team rating of the last generated team."""
     teams = db.get_last_teams()
     team = teams[args.team]
-    if not team:
+    if not team.players:
         print(f"❌ No previous team '{args.team}' found.")
         return
     overall_rating = team.get_overall_rating()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -277,3 +277,15 @@ def test_import_csv(tmp_path, reset_database):
     result = run_cli_command(["player", "list"])
     assert "Imported Player 1" in result.stdout
     assert "Imported Player 2" in result.stdout
+
+
+def test_get_team_attributes_no_previous_team(reset_database):
+    """Ensure friendly message when requesting attributes with no teams."""
+    result = run_cli_command(["teams", "attributes", "team1"])
+    assert "No previous team 'team1' found" in result.stdout
+
+
+def test_get_team_rating_no_previous_team(reset_database):
+    """Ensure friendly message when requesting rating with no teams."""
+    result = run_cli_command(["teams", "rating", "team1"])
+    assert "No previous team 'team1' found" in result.stdout


### PR DESCRIPTION
## Summary
- fix CLI functions to detect missing teams
- add CLI tests for missing teams

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684094f550f0832cb605d02bd8fb7bd7