### PR TITLE
Fix docstring param names

### DIFF
--- a/src/player.py
+++ b/src/player.py
@@ -151,7 +151,7 @@ class Player:
 
         The multiplier is 1 + 0.05 * (form - 5). That is, form 5 is neutral.
 
-        :param round:
+        :param round_num:
             Whether to round to 2 decimals. This should only be True if
             outputting to the end user.
 

--- a/src/teams.py
+++ b/src/teams.py
@@ -36,7 +36,7 @@ class Team:
         """
         Calculates the total adjusted team rating.
 
-        :param round:
+        :param round_num:
             Whether to round to 2 decimals. This should only be True if
             outputting to the end user.
 


### PR DESCRIPTION
## Summary
- update parameter description names in docstrings for `get_overall_rating`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684094f4ecfc832ca2bffd77011a6790